### PR TITLE
修复主题兼容性与导航菜单Bug

### DIFF
--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -61,8 +61,8 @@
         <iconify-icon class="group-hover:scale-125 transition-transform" icon="<%- icon %>" width="22">
         </iconify-icon>
         <% } %>
-        <% if (theme.nav[i].show_name != false && theme.nav[i].name) { %>
-        <p><%= theme.nav[i].name %></p>
+        <% if (theme.nav[i].show_name != false && theme.nav[i].text) { %>
+        <p><%= theme.nav[i].text %></p>
         <% } %>
       </a>
       <% } %>
@@ -135,7 +135,7 @@
       <iconify-icon icon="<%- theme.nav[i].icon %>" width="22">
       </iconify-icon>
       <p>
-        <%= theme.nav[i].name %>
+        <%= theme.nav[i].text %>
       </p>
     </a>
     <% } else { %>
@@ -154,3 +154,4 @@
     <% } %>
   </div>
 </div>
+

--- a/layout/_partial/post-list.ejs
+++ b/layout/_partial/post-list.ejs
@@ -16,7 +16,7 @@
             text-[var(--c-theme)]
             opacity-10
             dark:opacity-20
-            <%= config.theme_config.year_align_center ? 'text-center' : '-translate-x-3' %>
+            <%= theme.year_align_center ? 'text-center' : '-translate-x-3' %>
             ">
             <%- cur_year %>
           </p>
@@ -29,3 +29,4 @@
     </div>
   <% }) %>
 </section>
+


### PR DESCRIPTION
你好，这个 PR 修复了我在 Issue #4 中提到的问题。

改动:
1.  'layout/_partial/post-list.ejs': 将 'config.theme_config.year_align_center' 修改为 'theme.year_align_center'，用来兼容新版 Hexo。
2.  'layout/_partial/header.ejs': 将导航菜单文字的读取键从 'name' 修改为 'text'，和主题默认配置保持一致。

这些修改可以让新用户在配置主题时避免遇到同样的问题。

感谢！